### PR TITLE
Notifications activate user account manually front

### DIFF
--- a/src/app/pages/users/list/users-list.component.ts
+++ b/src/app/pages/users/list/users-list.component.ts
@@ -33,18 +33,14 @@ export class UsersListComponent implements OnInit {
 
   public ngOnInit(): void {
     let userId: string = null;
-    // Check we are in /users/id route and get User ID if so
-    if (this.activatedRoute.snapshot.params['id']) {
+    // Check we are in /users/id route and get User ID if so or don't go further if user not authorize to update
+    if (this.activatedRoute.snapshot.params['id'] &&
+        !this.authorizationService.canUpdateUser()) {
+        this.router.navigate(['/']);
+    } else {
       this.activatedRoute.params.subscribe((params: Params) => {
         userId = params['id'];
       });
-    }
-    if (userId) {
-      // Don't go further if user cannot update user
-      if (this.activatedRoute.snapshot.params['id'] &&
-        !this.authorizationService.canUpdateUser()) {
-        this.router.navigate(['/']);
-      }
       this.centralServerService.getUser(userId).subscribe((user) => {
         const editAction = new TableEditUserAction().getActionDef();
         if (editAction.action) {

--- a/src/app/pages/users/user/user.component.ts
+++ b/src/app/pages/users/user/user.component.ts
@@ -2,7 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import { Component, Inject, Input, OnInit } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
-import { ActivatedRoute, Params, Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { mergeMap } from 'rxjs/operators';
 
@@ -115,11 +115,6 @@ export class UserComponent extends AbstractTabComponent implements OnInit {
     windowService: WindowService) {
     super(activatedRoute, windowService, ['common', 'notifications', 'address', 'password', 'connections', 'miscs'], false);
     this.maxSize = this.configService.getUser().maxPictureKb;
-    // Check auth
-    if (this.activatedRoute.snapshot.params['id'] &&
-      !authorizationService.canUpdateUser()) {
-      this.router.navigate(['/']);
-    }
     // Get statuses
     this.userStatuses = USER_STATUSES;
     // Get Roles
@@ -275,13 +270,11 @@ export class UserComponent extends AbstractTabComponent implements OnInit {
     this.sendComputeAndApplyChargingProfilesFailed = this.notifications.controls['sendComputeAndApplyChargingProfilesFailed'];
     this.sendEndUserErrorNotification = this.notifications.controls['sendEndUserErrorNotification'];
     this.sendBillingNewInvoice = this.notifications.controls['sendBillingNewInvoice'];
+    if (this.activatedRoute.snapshot.url[0]?.path === 'profile') {
+      this.currentUserID = this.centralServerService.getLoggedUser().id;
+    }
     if (this.currentUserID) {
       this.loadUser();
-    } else if (this.activatedRoute && this.activatedRoute.params) {
-      this.activatedRoute.params.subscribe((params: Params) => {
-        this.currentUserID = params['id'];
-        this.loadUser();
-      });
     }
     this.loadRefundSettings();
     if (!this.inDialog) {

--- a/src/app/pages/users/users.component.ts
+++ b/src/app/pages/users/users.component.ts
@@ -19,8 +19,8 @@ export class UsersComponent extends AbstractTabComponent {
       authorizationService: AuthorizationService,
       windowService: WindowService) {
       super(activatedRoute, windowService, ['all', 'tag', 'inerror']);
-    this.canListUsers = authorizationService.canListUsers();
-    this.canListTokens = authorizationService.canListTokens();
-    this.canListUsersInError = authorizationService.canListUsersInError();
+      this.canListUsers = authorizationService.canListUsers();
+      this.canListTokens = authorizationService.canListTokens();
+      this.canListUsersInError = authorizationService.canListUsersInError();
   }
 }

--- a/src/app/pages/users/users.routing.ts
+++ b/src/app/pages/users/users.routing.ts
@@ -16,7 +16,15 @@ export const UserRoutes: Routes = [
     },
   },
   {
-    path: ':id', component: UserComponent, canActivate: [RouteGuardService], data: {
+    path: 'profile', component: UserComponent, canActivate: [RouteGuardService], data: {
+      auth: {
+        entity: Entity.USER,
+        action: Action.UPDATE,
+      },
+    },
+  },
+  {
+    path: ':id', component: UsersComponent, canActivate: [RouteGuardService], data: {
       auth: {
         entity: Entity.USER,
         action: Action.UPDATE,

--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -35,7 +35,7 @@
         <ul class="nav">
           <li *ngIf="canEditProfile" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}"
             class="nav-item">
-            <a [routerLink]="['/users/' + loggedUser?.id ]" class="nav-link">
+            <a [routerLink]="['/users/profile' ]" class="nav-link">
               <span class="sidebar-mini"><i class="material-icons sidebar-mini-icons">portrait</i></span>
               <span class="sidebar-normal">{{'users.profile' | translate}}</span>
             </a>

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2202,7 +2202,7 @@
     "session_not_started": "Benachrichtigen Sie mich, wenn kein Ladevorgang nach dem authentifizieren gestartet wurde",
     "user_account_inactivity": "Benachrichtigen Sie mich, wenn ich mich seit mehr als 6 Monaten nicht eingeloggt habe",
     "car_catalog_synchronization_failed": "Benachrichtigen Sie mich, wenn bei der Synchronisierung der Fahrzeuge ein Fehler auftrat",
-    "compute_and_apply_charging_profiles_failed": "Benachrichtigen Sie mich, wenn das Anwenden der Smart Charging-Profile für einen Standortbereich fehlschlägt",
+    "compute_and_apply_charging_profiles_failed": "Notify me when applying the smart charging profiles fails for a site area",
     "end_user_error_notification": "Benachrichtigen Sie mich, wenn ein Nutzer einen Fehler meldet",
     "billing_new_invoice": "Benachrichtigen Sie mich, wenn eine neue Rechnung verfügbar ist"
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2201,8 +2201,8 @@
     "billing_synchronization_failed": "Notify me when a synchronization with billing system has failed",
     "session_not_started": "Notify me if no session has been started after badging",
     "user_account_inactivity": "Notify me when I haven't logged in to the application for more than 6 months",
-    "compute_and_apply_charging_profiles_failed": "Notify me when applying the Smart Charging-Profiles fails for a certain site area",
     "car_catalog_synchronization_failed": "Notify me if an error has occurred while synchronization cars, check the logs",
+    "compute_and_apply_charging_profiles_failed": "Notify me when applying the smart charging profiles fails for a site area",
     "end_user_error_notification": "Notify me when a user reports an error",
     "billing_new_invoice": "Notify me when a new invoice is available"
   }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2201,8 +2201,8 @@
     "billing_synchronization_failed": "Notificarme si ha fallado la sincronización con el sistema de facturación",
     "session_not_started": "Notificarme si no se inició ninguna sesión después de la identificación",
     "user_account_inactivity": "Notificarme cuando no haya iniciado sesión en la aplicación durante más de 6 meses",
-    "compute_and_apply_charging_profiles_failed": "Notify me when applying the Smart Charging-Profiles fails for a certain site area",
     "car_catalog_synchronization_failed": "Notificarme si se ha producido un error durante la sincronización de los automóviles",
+    "compute_and_apply_charging_profiles_failed": "Notify me when applying the smart charging profiles fails for a site area",
     "end_user_error_notification": "Notificarme cuando un usuario reporte algún error",
     "billing_new_invoice": "Notify me when a new invoice is available"
   }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -2202,7 +2202,7 @@
     "session_not_started": "Me notifier lorsque j'ai badger sur une borne de recharge mais aucune session n'a démarré",
     "user_account_inactivity": "Me notifier lorsque je ne me suis pas connecté à l'application depuis plus de 6 mois",
     "car_catalog_synchronization_failed": "Me notifier lorsqu'une synchronisation de véhicule a échoué",
-    "compute_and_apply_charging_profiles_failed": "Notify me when applying the Smart Charging Profiles-fails for a certain site area",
+    "compute_and_apply_charging_profiles_failed": "Me notifier lorsque les profiles pour le smart charging échouent sur une zone",
     "end_user_error_notification": "Me notifier lorsque l'utilisateur me rapporte un problème",
     "billing_new_invoice": "Me notifier lorsqu'une nouvelle facture est disponible"
   }

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2201,8 +2201,8 @@
     "billing_synchronization_failed": "Avvisami quando una sincronizzazione con un sistema di fatturazione non è riuscita",
     "session_not_started": "Avvisami se nessuna sessione è stata avviata dopo l'inserimento di un badge",
     "user_account_inactivity": "Avvisami quando non accedo all'applicazione da più di 6 mesi",
-    "compute_and_apply_charging_profiles_failed": "Avvisami quando l'applicazione dei profili di ricarica intelligenti non riesce per una determinata area del sito",
     "car_catalog_synchronization_failed": "Avvisami se si verifica un errore durante la sincronizzazione delle vetture",
+    "compute_and_apply_charging_profiles_failed": "Notify me when applying the smart charging profiles fails for a site area",
     "end_user_error_notification": "Avvisami quando un utente riporta un errore",
     "billing_new_invoice": "Avvisami quando è disponibile una nuova fattura"
   }

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2201,8 +2201,8 @@
     "billing_synchronization_failed": "Notifique-me quando uma sincronização com o sistema de faturamento falhar",
     "session_not_started": "Notifique-me se nenhuma sessão tiver sido iniciada após o selo",
     "user_account_inactivity": "Notifique-me quando eu não fizer login no aplicativo por mais de 6 meses",
-    "compute_and_apply_charging_profiles_failed": "Notify me when applying the Smart Charging-Profiles fails for a certain site area",
     "car_catalog_synchronization_failed": "Notifique-me se ocorrer um erro durante os carros de sincronização",
+    "compute_and_apply_charging_profiles_failed": "Notify me when applying the smart charging profiles fails for a site area",
     "end_user_error_notification": "Notifique-me quando um utilizador relatar um erro",
     "billing_new_invoice": "Notify me when a new invoice is available"
   }


### PR DESCRIPTION
added new route to handle "profile" page
modified users/id route to nicely display the modal - used when admin clicks on the link of the email received to validate user account